### PR TITLE
Add docker image, documentation, workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,49 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        version: latest
+
+    - name: Log in to GitHub Container Registry (GHCR)
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Get version from package.json
+      id: get-version
+      run: |
+        VERSION=$(node -p "require('./package.json').version")
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "Found version: $VERSION"
+
+    - name: Build Docker image
+      run: |
+        # Define image names for both the version and latest tags
+        VERSION_TAG=ghcr.io/${{ github.repository }}:${{ env.VERSION }}
+        LATEST_TAG=ghcr.io/${{ github.repository }}:latest
+        echo "Building Docker image with tags: $VERSION_TAG and $LATEST_TAG"
+        docker build -t $VERSION_TAG -t $LATEST_TAG .
+
+    - name: Push Docker images to GHCR
+      run: |
+        VERSION_TAG=ghcr.io/${{ github.repository }}:${{ env.VERSION }}
+        LATEST_TAG=ghcr.io/${{ github.repository }}:latest
+        echo "Pushing Docker images to GHCR: $VERSION_TAG and $LATEST_TAG"
+        docker push $VERSION_TAG
+        docker push $LATEST_TAG

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,14 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v3
 
+    - name: Cache Node modules
+      uses: actions/cache@v3
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-modules-
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
       with:
@@ -32,13 +40,23 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "Found version: $VERSION"
 
+    - name: Cache Docker layers
+      id: cache-docker
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-docker-${{ hashFiles('Dockerfile', 'package.json', 'package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-docker-
+
     - name: Build Docker image
       run: |
-        # Define image names for both the version and latest tags
         VERSION_TAG=ghcr.io/${{ github.repository }}:${{ env.VERSION }}
         LATEST_TAG=ghcr.io/${{ github.repository }}:latest
         echo "Building Docker image with tags: $VERSION_TAG and $LATEST_TAG"
-        docker build -t $VERSION_TAG -t $LATEST_TAG .
+        docker build \
+          --cache-from=type=local,src=/tmp/.buildx-cache \
+          -t $VERSION_TAG -t $LATEST_TAG .
 
     - name: Push Docker images to GHCR
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:lts-alpine3.20
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json first for dependency installation
+COPY package*.json ./
+
+# Install the dependencies
+RUN npm install
+
+# Copy the rest of the application code into the container
+COPY index.js .
+
+# Expose port 7969
+EXPOSE 7969
+
+# Command to run the application, using the environment variables
+CMD node index.js --blueskyidentifier $IDENTIFIER --blueskypass $PASS

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ If you're self-hosting a ghost app, you should be able to start this app on the 
 
 ## Usage 
 
-First you'll need your blueky handle and an app password. The integration will work with your regular password but you should instead create an app password so you're not slinging around your actual password. You can find instructions on how to create an app password here: 
+First you'll need your bluesky handle and an app password. The integration will work with your regular password but you should instead create an app password so you're not slinging around your actual password. You can find instructions on how to create an app password here: 
 
 https://lifehacker.com/tech/why-you-should-be-using-bluesky-app-passwords
 
@@ -25,3 +25,32 @@ You can configure the port:
 Otherwise it will default to port 7969.
 
 Then add a custom integration and add the url `http://127.0.0.1:7969/post-published` to the ghost "post published" webhook.
+
+### Docker
+
+The Dockerfile takes your identifier and app password as environment variables:
+
+```bash
+docker run --name ghost-bluesky-integration \
+-e IDENTIFIER=<your Bluesky identifier> \
+-e PASS=<your App Password> \
+-p 7969:7969 \
+--restart=unless-stopped \
+ghcr.io/psharma04/ghost-bluesky-integration:latest
+```
+
+Alternatively as a `docker-compose` file:
+
+```yaml
+version: "3.3"
+services:
+  ghost-bluesky-integration:
+    container_name: ghost-bluesky-integration
+    environment:
+      - IDENTIFIER=<your Bluesky identifier>
+      - PASS=<your App Password>
+    ports:
+      - 7969:7969
+    restart: unless-stopped
+    image: ghcr.io/psharma04/ghost-bluesky-integration:latest
+```

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ docker run --name ghost-bluesky-integration \
 -e PASS=<your App Password> \
 -p 7969:7969 \
 --restart=unless-stopped \
-ghcr.io/psharma04/ghost-bluesky-integration:latest
+ghcr.io/Elliotclyde/ghost-bluesky-integration:latest
 ```
 
 Alternatively as a `docker-compose` file:
@@ -52,5 +52,5 @@ services:
     ports:
       - 7969:7969
     restart: unless-stopped
-    image: ghcr.io/psharma04/ghost-bluesky-integration:latest
+    image: ghcr.io/Elliotclyde/ghost-bluesky-integration:latest
 ```


### PR DESCRIPTION
This PR adds a `Dockerfile` for the project, enabling all the usual advantages of containerised projects (no dependency installing, 1-line setup).

I've added documentation for running the project using either a direct `docker run` command, or through a compose file for those who would prefer that.

There's also a GitHub workflow, so that an updated Docker image is produced every time the `main` branch is updated. It is versioned based on the `package.json` data.