### PR TITLE
Split USETITLE logic into seperate start script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@ RUN npm install
 
 # Copy the rest of the application code into the container
 COPY index.js .
+ADD src /usr/src/app/src
 
 # Expose port 7969
 EXPOSE 7969
 
-# Command to run the application, using the environment variables
-CMD if [ $USETITLE = 'TRUE' ]; then \
-        node index.js --blueskyidentifier $IDENTIFIER --blueskypass $PASS --usetitle \
-    else \
-        node index.js --blueskyidentifier $IDENTIFIER --blueskypass $PASS \
-    fi
+# Copy the start script into the container
+COPY start.sh /usr/src/app
+
+# Command to run the application
+CMD "./start.sh"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghost-bluesky-integration",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghost-bluesky-integration",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-bluesky-integration",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Integration between ghost CMS and bluesky",
   "main": "index.js",
   "type": "module",

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ "$USETITLE" = "TRUE" ]; then
+    node index.js --blueskyidentifier "$IDENTIFIER" --blueskypass "$PASS" --usetitle
+else
+    node index.js --blueskyidentifier "$IDENTIFIER" --blueskypass "$PASS"
+fi


### PR DESCRIPTION
Hiya, I was getting errors with using the image from GHCR via Docker compose, specifically the last `fi` in the if/else statement.

I split the logic for the $USETITLE variable into a separate start script, and this worked, and the container is now able to start successfully.